### PR TITLE
Updating chart styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onsvisual/svelte-charts",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onsvisual/svelte-charts",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.0",
@@ -33,7 +33,7 @@
         "layercake": "^7.6.1",
         "regl": "latest",
         "regl-tween": "latest",
-        "svelte": "3 - 5"
+        "svelte": "3 - 4"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/charts/BarChart.svelte
+++ b/src/charts/BarChart.svelte
@@ -78,8 +78,6 @@
 	export let xTicksArray = [parseInt(xTicksEmpty)];
 	export let xFormatTickArray;
 
-
-
 	let xTicksArrayNum = xTicksArray.map(number => parseFloat(number))
 
 	let el; // Chart DOM element
@@ -133,6 +131,7 @@
 
 	// Create a data series for each zKey (group)
 	$: groupedData = groupData(data, _zDomain, zKey);
+
 </script>
 
 <div bind:this={el}>
@@ -148,7 +147,11 @@
 <slot name="legend"/>
 {#if legend && _zDomain}
   <Legend domain={_zDomain} {colors} {markerWidth} horizontal={false} line={mode == 'barcode'} comparison={mode == 'comparison'} confidence={mode == 'confidence'} {yAxisLabel}/>
-{/if}
+  {/if}
+  {#if yAxisLabel}
+  <div style="margin-top: 40px"></div>
+  {/if} 
+  <!-- if there is no legend, then the yaxislabel gets cut off by the subtitle so this adds a bit of padding for the yaxislabel to show properly -->
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? `${height}px` : height ?  height : yDomain ? `${padding.top + padding.bottom + (barHeight * yDomain.length)}px` : "300px" }" aria-hidden="true">
 	<LayerCake
@@ -191,7 +194,7 @@
       {#if yAxis}
 			  <AxisY gridlines={false} prefix={yPrefix} suffix={ySuffix} {textColor} {tickColor} {tickDashed} wrapTicks={yWrapTicks} {yAxisLabel}/>
       {/if}
-			<Bar {select} {selected} {hover} {hovered} {highlighted} {directLabel} {xFormatTickString} on:hover on:select {overlayFill}/>
+			<Bar {select} {selected} {hover} {hovered} {highlighted} {directLabel} {xFormatTickString} on:hover on:select {overlayFill} bind:suffix={xSuffix} bind:prefix={xPrefix} bind:barHeight/>
 			<slot name="svg"/>
 		</Svg>
 	  <slot name="front"/>

--- a/src/charts/BarChart.svelte
+++ b/src/charts/BarChart.svelte
@@ -3,7 +3,7 @@
 <script>
 	import { LayerCake, Svg } from 'layercake';
 	import { scaleBand, scaleOrdinal, scaleLinear, scaleSymlog } from 'd3-scale';
-  import { tweened } from 'svelte/motion';
+  	import { tweened } from 'svelte/motion';
 	import { cubicInOut } from 'svelte/easing';
 	import { groupData, commas } from '../js/utils';
 
@@ -18,14 +18,14 @@
 	import Export from './shared/Export.svelte';
 	import Table from './shared/Table.svelte';
 
-  export let data;
+  	export let data;
 	export let barHeight = 40; // height of individual bar (overridden if height is set)
 	export let height = null; // number of pixels or valid css height string
 	export let ssr = false;
 	export let ssrWidth = 300; // for SSR only. Must be a number
 	export let ssrHeight = typeof height == 'number' ? height : 300; // for SSR only. Number, or calculated from 'height'
-  export let animation = true;
-  export let duration = 800;
+	export let animation = true;
+	export let duration = 800;
 	export let xKey = 'x';
 	export let yKey = 'y';
 	export let zKey = null;
@@ -35,12 +35,12 @@
 	export let yWrapTicks = true;
 	export let xMax = null;
 	export let xMin = null;
-  export let xAxis = true;
-  export let yAxis = true;
+	export let xAxis = true;
+	export let yAxis = true;
 	export let xTicks = 4;
 	export let zDomain = null;
 	export let textColor = '#666';
-	export let tickColor = '#ccc';
+	export let tickColor = '#d9d9d9';
 	export let tickDashed = false;
 	export let title = null;
 	export let subtitle = null;
@@ -70,6 +70,17 @@
 	export let colorHighlight = 'black';
 	export let overlayFill = false;
 	export let output = null;
+	export let xAxisLabel = "";
+	export let yAxisLabel = "";
+	export let directLabel;
+	export let xFormatTickString;
+	export let xTicksEmpty = null; //null var that we can push the xTicksArray into
+	export let xTicksArray = [parseInt(xTicksEmpty)];
+	export let xFormatTickArray;
+
+
+
+	let xTicksArrayNum = xTicksArray.map(number => parseFloat(number))
 
 	let el; // Chart DOM element
 
@@ -134,6 +145,10 @@
 {#if alt}
 	<h5 class="visuallyhidden">{alt}</h5>
 {/if}
+<slot name="legend"/>
+{#if legend && _zDomain}
+  <Legend domain={_zDomain} {colors} {markerWidth} horizontal={false} line={mode == 'barcode'} comparison={mode == 'comparison'} confidence={mode == 'confidence'} {yAxisLabel}/>
+{/if}
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? `${height}px` : height ?  height : yDomain ? `${padding.top + padding.bottom + (barHeight * yDomain.length)}px` : "300px" }" aria-hidden="true">
 	<LayerCake
@@ -157,25 +172,26 @@
 			type: 'bar',
 			mode,
 			idKey,
-      coords,
+      		coords,
 			markerWidth,
 			colorSelect,
 			colorHover,
 			colorHighlight,
-      animation,
-      duration
+      		animation,
+      		duration
     }}
 	>
+
 	  <SetCoords/>
 	  <slot name="back"/>
 		<Svg pointerEvents={interactive}>
       {#if xAxis}
-			  <AxisX ticks={xTicks} formatTick={xFormatTick} {snapTicks} prefix={xPrefix} suffix={xSuffix} {textColor} {tickColor} {tickDashed}/>
+			  <AxisX ticks={xTicks} formatTick={xFormatTick} {snapTicks} prefix={xPrefix} suffix={xSuffix} {textColor} {tickColor} {tickDashed} {xAxisLabel} xTicksArray={xTicksArrayNum} {xFormatTickArray}/>
       {/if}
       {#if yAxis}
-			  <AxisY gridlines={false} prefix={yPrefix} suffix={ySuffix} {textColor} {tickColor} {tickDashed} wrapTicks={yWrapTicks}/>
+			  <AxisY gridlines={false} prefix={yPrefix} suffix={ySuffix} {textColor} {tickColor} {tickDashed} wrapTicks={yWrapTicks} {yAxisLabel}/>
       {/if}
-			<Bar {select} {selected} {hover} {hovered} {highlighted} on:hover on:select {overlayFill}/>
+			<Bar {select} {selected} {hover} {hovered} {highlighted} {directLabel} {xFormatTickString} on:hover on:select {overlayFill}/>
 			<slot name="svg"/>
 		</Svg>
 	  <slot name="front"/>
@@ -185,10 +201,6 @@
 <div class="visuallyhidden">
 	<Table {data} key1={yKey} key2={xKey}/>
 </div>
-{/if}
-<slot name="legend"/>
-{#if legend && _zDomain}
-  <Legend domain={_zDomain} {colors} {markerWidth} horizontal={false} line={mode == 'barcode'} comparison={mode == 'comparison'} confidence={mode == 'confidence'}/>
 {/if}
 {#if footer}
   <Footer>{footer}</Footer>

--- a/src/charts/Chart.svelte
+++ b/src/charts/Chart.svelte
@@ -55,14 +55,16 @@
       });
     }
     directions.forEach(dir => {
-      if (section[`padding-${dir}`]) padding[dir] = section[`padding-${dir}`];
+      if (section[`padding-${dir}`]) padding[dir] = +(section[`padding-${dir}`]);
     });
     props.padding = padding;
+    
     if (!props.legend && props.legend !== false) props.legend = props.zKey ? true : false;
     return props;
   }
 
   $: props = makeProps(type, data, options, section);
+  // $: console.log(props)
 </script>
 
 {#if props}

--- a/src/charts/ColumnChart.svelte
+++ b/src/charts/ColumnChart.svelte
@@ -64,6 +64,8 @@
 	export let colorHighlight = 'black';
 	export let overlayFill = false;
 	export let output = null;
+	export let xAxisLabel = "";
+	export let yAxisLabel = "";
 
 	let el; // Chart DOM element
 
@@ -116,6 +118,7 @@
 	
 	// Create a data series for each zKey (group)
 	$: groupedData = groupData(data, _zDomain, zKey);
+	// $: console.log(groupedData)
 </script>
 
 <div bind:this={el}>
@@ -127,6 +130,10 @@
 {/if}
 {#if alt}
 	<h5 class="visuallyhidden">{alt}</h5>
+{/if}
+<slot name="legend"/>
+{#if legend && _zDomain}
+  <Legend domain={_zDomain} {colors} {markerWidth} line={mode == 'barcode'} comparison={mode == 'comparison'} confidence={mode == 'confidence'} {yAxisLabel}/>
 {/if}
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? height + 'px' : height }" aria-hidden="true">
@@ -164,10 +171,10 @@
 	  <slot name="back"/>
 		<Svg pointerEvents={interactive}>
       {#if xAxis}
-			  <AxisX gridlines={false} prefix={xPrefix} suffix={xSuffix}/>
+			  <AxisX gridlines={false} prefix={xPrefix} suffix={xSuffix} {xAxisLabel}/>
       {/if}
       {#if yAxis}
-			  <AxisY ticks={yTicks} formatTick={yFormatTick} prefix={yPrefix} suffix={ySuffix}/>
+			  <AxisY ticks={yTicks} formatTick={yFormatTick} prefix={yPrefix} suffix={ySuffix} {yAxisLabel}/>
       {/if}
 			<Column {select} {selected} {hover} {hovered} {highlighted} on:hover on:select {overlayFill}/>
 			<slot name="svg"/>
@@ -179,10 +186,6 @@
 <div class="visuallyhidden">
 	<Table {data} key1={xKey} key2={yKey}/>
 </div>
-{/if}
-<slot name="legend"/>
-{#if legend && _zDomain}
-  <Legend domain={_zDomain} {colors} {markerWidth} line={mode == 'barcode'} comparison={mode == 'comparison'} confidence={mode == 'confidence'}/>
 {/if}
 {#if footer}
   <Footer>{footer}</Footer>

--- a/src/charts/ColumnChart.svelte
+++ b/src/charts/ColumnChart.svelte
@@ -135,6 +135,10 @@
 {#if legend && _zDomain}
   <Legend domain={_zDomain} {colors} {markerWidth} line={mode == 'barcode'} comparison={mode == 'comparison'} confidence={mode == 'confidence'} {yAxisLabel}/>
 {/if}
+{#if yAxisLabel}
+<div style="margin-top: 40px"></div>
+{/if} 
+<!-- if there is no legend, then the yaxislabel gets cut off by the subtitle so this adds a bit of padding for the yaxislabel to show properly -->
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? height + 'px' : height }" aria-hidden="true">
 	<LayerCake

--- a/src/charts/DotPlotChart.svelte
+++ b/src/charts/DotPlotChart.svelte
@@ -39,7 +39,7 @@
 	export let xTicks = 4; // Number of ticks or array of tick values, eg [0, 10, 100, 1000]
 	export let zDomain = null;
 	export let textColor = '#666';
-	export let tickColor = '#ccc';
+	export let tickColor = '#d9d9d9';
 	export let tickDashed = false;
 	export let title = null;
 	export let subtitle = null;
@@ -70,6 +70,12 @@
 	export let colorHighlight = 'black';
 	export let overlayFill = false;
 	export let output = null;
+	export let xAxisLabel = "";
+	export let yAxisLabel = "";
+	export let xTicksEmpty = null; //null var that we can push the xTicksArray into
+	export let xTicksArray = [parseInt(xTicksEmpty)];
+
+	let xTicksArrayNum = xTicksArray.map(number => parseFloat(number))
 
 	let el; // Chart DOM element
 
@@ -119,6 +125,10 @@
 {#if alt}
 	<h5 class="visuallyhidden">{alt}</h5>
 {/if}
+<slot name="legend"/>
+{#if false && legend && _zDomain}
+  <Legend domain={_zDomain} {colors} horizontal={false} line={mode == 'barcode'} comparison={mode == 'comparison'} {yAxisLabel}/>
+{/if}
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? `${height}px` : height ?  height : yDomain ? `${padding.top + padding.bottom + (barHeight * yDomain.length)}px` : "300px" }" aria-hidden="true">
 	<LayerCake
@@ -157,10 +167,10 @@
 	  <slot name="back"/>
 		<Svg pointerEvents={interactive}>
       {#if xAxis}
-			  <AxisX ticks={xTicks} formatTick={xFormatTick} {snapTicks} prefix={xPrefix} suffix={xSuffix} {textColor} {tickColor} {tickDashed}/>
+			  <AxisX ticks={xTicks} formatTick={xFormatTick} {snapTicks} prefix={xPrefix} suffix={xSuffix} {textColor} {tickColor} {tickDashed} {xAxisLabel} xTicksArray={xTicksArrayNum}/>
       {/if}
       {#if yAxis}
-			  <AxisY gridlines={false} prefix={yPrefix} suffix={ySuffix} {textColor} {tickColor} {tickDashed}/>
+			  <AxisY gridlines={false} prefix={yPrefix} suffix={ySuffix} {textColor} {tickColor} {tickDashed} {yAxisLabel}/>
       {/if}
 			<DotPlot {select} {selected} {hover} {hovered} {highlighted} on:hover on:select {overlayFill}/>
 			<slot name="svg"/>
@@ -172,10 +182,6 @@
 <div class="visuallyhidden">
 	<Table {data} key1={yKey} key2={xKey}/>
 </div>
-{/if}
-<slot name="legend"/>
-{#if false && legend && _zDomain}
-  <Legend domain={_zDomain} {colors} horizontal={false} line={mode == 'barcode'} comparison={mode == 'comparison'}/>
 {/if}
 {#if footer}
   <Footer>{footer}</Footer>

--- a/src/charts/DotPlotChart.svelte
+++ b/src/charts/DotPlotChart.svelte
@@ -129,6 +129,10 @@
 {#if false && legend && _zDomain}
   <Legend domain={_zDomain} {colors} horizontal={false} line={mode == 'barcode'} comparison={mode == 'comparison'} {yAxisLabel}/>
 {/if}
+{#if yAxisLabel}
+<div style="margin-top: 40px"></div>
+{/if} 
+<!-- if there is no legend, then the yaxislabel gets cut off by the subtitle so this adds a bit of padding for the yaxislabel to show properly -->
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? `${height}px` : height ?  height : yDomain ? `${padding.top + padding.bottom + (barHeight * yDomain.length)}px` : "300px" }" aria-hidden="true">
 	<LayerCake

--- a/src/charts/LineChart.svelte
+++ b/src/charts/LineChart.svelte
@@ -152,6 +152,10 @@
 {#if legend && _zDomain}
   <Legend domain={_zDomain} {colors} {line} markerWidth={lineWidth} {yAxisLabel}/>
 {/if}
+{#if yAxisLabel}
+<div style="margin-top: 40px"></div>
+{/if} 
+<!-- if there is no legend, then the yaxislabel gets cut off by the subtitle so this adds a bit of padding for the yaxislabel to show properly -->
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? height + 'px' : height }" aria-hidden="true">
 	<LayerCake

--- a/src/charts/LineChart.svelte
+++ b/src/charts/LineChart.svelte
@@ -20,7 +20,7 @@
 	import Export from './shared/Export.svelte';
 	import Table from './shared/Table.svelte';
 
-  export let data;
+  	export let data;
 	export let height = 200; // number of pixels or valid css height string
 	export let ssr = false;
 	export let ssrWidth = 300; // for SSR only. Must be a number
@@ -66,7 +66,7 @@
 	export let padding = { top: 0, bottom: 28, left: 35, right: 0 };
 	export let color = null;
 	export let colors = color ? [color] : ['#206095', '#A8BD3A', '#003C57', '#27A0CC', '#118C7B', '#F66068', '#746CB1', '#22D0B6', 'lightgrey'];
-	export let lineWidth = 2.5;
+	export let lineWidth = 3;
 	export let interactive = true;
 	export let xPrefix = "";
 	export let xSuffix = "";
@@ -81,6 +81,14 @@
 	export let highlighted = [];
 	export let colorHighlight = '#206095';
 	export let output = null;
+	export let xAxisLabel = "";
+	export let yAxisLabel = "";
+	export let xTicksEmpty = null; //null var that we can push the xTicksArray into
+	export let xTicksArray = [parseInt(xTicksEmpty)];
+	export let xFormatTickArray;
+
+	let xTicksArrayNum = xTicksArray.map(number => parseFloat(number))
+
 
 	let el; // Chart DOM element
 
@@ -104,7 +112,7 @@
 	}
 
 	// Functions to animate yDomain
-	const yDomSet = (data, mode, yKey, yMax) => yMax ? [yMin, yMax] : mode == 'stacked' && yKey ? [yMin, Math.max(...getTotals(data, data.map(d => d[xKey]).filter(distinct)))] : [Math.min(...data.map(d => d[yKey])), Math.max(...data.map(d => d[yKey]))];
+	const yDomSet = (data, mode, yKey, yMax) => yMax ? [yMin, yMax] : mode == 'stacked' && yKey ? [yMin, Math.max(...getTotals(data, data.map(d => d[xKey]).filter(distinct)))] : yMin == 'auto' ? [Math.min(...data.map(d => d[yKey])), Math.max(...data.map(d => d[yKey]))] : [yMin, Math.max(...data.map(d => d[yKey]))];
 	function yDomUpdate(data, mode, yKey, yMax) {
 		let newYDom = yDomSet(data, mode, yKey, yMax);
 		if (newYDom[0] != yDom[0] || newYDom[1] != yDom[1]) {
@@ -139,6 +147,10 @@
 {/if}
 {#if alt}
 	<h5 class="visuallyhidden">{alt}</h5>
+{/if}
+<slot name="legend"/>
+{#if legend && _zDomain}
+  <Legend domain={_zDomain} {colors} {line} markerWidth={lineWidth} {yAxisLabel}/>
 {/if}
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? height + 'px' : height }" aria-hidden="true">
@@ -175,10 +187,10 @@
 	  <slot name="back"/>
 		<Svg pointerEvents={interactive}>
       {#if xAxis}
-			  <AxisX ticks={xTicks} formatTick={xFormatTick} {snapTicks} prefix={xPrefix} suffix={xSuffix} gridlines={xGridlines} tickMarks={xTickMarks} forceTicks={xForceTicks} formatTickString={xFormatTickString}/>
+			  <AxisX ticks={xTicks} formatTick={xFormatTick} {snapTicks} prefix={xPrefix} suffix={xSuffix} gridlines={xGridlines} tickMarks={xTickMarks} forceTicks={xForceTicks} formatTickString={xFormatTickString} {xAxisLabel} xTicksArray={xTicksArrayNum} {xFormatTickArray}/>
       {/if}
       {#if yAxis}
-			  <AxisY ticks={yTicks} formatTick={yFormatTick} prefix={yPrefix} suffix={ySuffix} trimGridlines={yTrimGridlines}/>
+			  <AxisY ticks={yTicks} formatTick={yFormatTick} prefix={yPrefix} suffix={ySuffix} trimGridlines={yTrimGridlines} {yAxisLabel}/>
       {/if}
       {#if area}
 			  <Area {mode} opacity={areaOpacity}/>
@@ -198,10 +210,6 @@
 <div class="visuallyhidden">
 	<Table {data} key1={zKey} key2={xKey} key3={yKey}/>
 </div>
-{/if}
-<slot name="legend"/>
-{#if legend && _zDomain}
-  <Legend domain={_zDomain} {colors} {line} markerWidth={lineWidth}/>
 {/if}
 {#if footer}
   <Footer>{footer}</Footer>

--- a/src/charts/MarkerChart.svelte
+++ b/src/charts/MarkerChart.svelte
@@ -33,6 +33,11 @@
 	export let interactive = true;
 	export let xPrefix = "";
 	export let xSuffix = "";
+	export let xAxisLabel = "";
+	export let xTicksEmpty = null; //null var that we can push the xTicksArray into
+	export let xTicksArray = [parseInt(xTicksEmpty)];
+
+	let xTicksArrayNum = xTicksArray.map(number => parseFloat(number))
 
 	const tweenOptions = {
 		duration: duration,
@@ -56,6 +61,10 @@
 {/if}
 {#if alt}
 	<h5 class="visuallyhidden">{alt}</h5>
+{/if}
+<slot name="legend"/>
+{#if footer}
+  <Footer>{footer}</Footer>
 {/if}
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? height + 'px' : height }" aria-hidden="true">
@@ -83,7 +92,7 @@
 		<Svg pointerEvents={interactive}>
       <Stack ticks={xTicks}/>
       {#if xAxis}
-			  <AxisX ticks={xTicks} {snapTicks} prefix={xPrefix} suffix={xSuffix}/>
+			  <AxisX ticks={xTicks} {snapTicks} prefix={xPrefix} suffix={xSuffix} {xAxisLabel} xTicksArray={xTicksArrayNum}/>
       {/if}
 			<Bar mode="marker" {markerWidth}/>
 		</Svg>
@@ -91,10 +100,7 @@
 		{/if}
 	</LayerCake>
 </div>
-<slot name="legend"/>
-{#if footer}
-  <Footer>{footer}</Footer>
-{/if}
+
 
 <style>
 	.chart-container {

--- a/src/charts/ScatterChart.svelte
+++ b/src/charts/ScatterChart.svelte
@@ -50,7 +50,7 @@
 	export let zDomain = null;
 	export let yFitBeeswarm = false;
 	export let textColor = '#666';
-	export let tickColor = '#ccc';
+	export let tickColor = '#d9d9d9';
 	export let tickDashed = false;
 	export let title = null;
 	export let subtitle = null;
@@ -81,6 +81,13 @@
 	export let colorHighlight = 'black';
 	export let overlayFill = false;
 	export let output = null;
+	export let xAxisLabel = "";
+	export let yAxisLabel = "";
+	export let xTicksEmpty = null; //null var that we can push the xTicksArray into
+	export let xTicksArray = [parseInt(xTicksEmpty)];
+	export let xFormatTickArray;
+
+	let xTicksArrayNum = xTicksArray.map(number => parseFloat(number))
 
 	let el; // Chart DOM element
 
@@ -132,6 +139,10 @@
 {#if alt}
 	<h5 class="visuallyhidden">{alt}</h5>
 {/if}
+<slot name="legend"/>
+{#if legend && _zDomain}
+  <Legend domain={_zDomain} {colors} markerLength={12} round={true} {yAxisLabel}/>
+{/if}
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? height + 'px' : height }" aria-hidden="true">
 	<LayerCake
@@ -172,10 +183,10 @@
     <slot name="back"/>
 		<Svg pointerEvents={interactive}>
       {#if xAxis}
-			  <AxisX ticks={xTicks} formatTick={xFormatTick} {snapTicks} prefix={xPrefix} suffix={xSuffix} {textColor} {tickColor} {tickDashed} gridlines={xGridlines} tickMarks={xTickMarks}/>
+			  <AxisX ticks={xTicks} formatTick={xFormatTick} {snapTicks} prefix={xPrefix} suffix={xSuffix} {textColor} {tickColor} {tickDashed} gridlines={xGridlines} tickMarks={xTickMarks} {xAxisLabel} xTicksArray={xTicksArrayNum} {xFormatTickArray}/>
       {/if}
       {#if yAxis && yKey}
-			  <AxisY ticks={yTicks} formatTick={yFormatTick} prefix={yPrefix} suffix={ySuffix} {textColor} {tickColor} {tickDashed}/>
+			  <AxisY ticks={yTicks} formatTick={yFormatTick} prefix={yPrefix} suffix={ySuffix} {textColor} {tickColor} {tickDashed} {yAxisLabel}/>
       {/if}
 			<Scatter {selected} {hovered} {highlighted} {overlayFill}/>
 			{#if select || hover}
@@ -193,10 +204,6 @@
 <div class="visuallyhidden">
 	<Table {data} key1={zKey} key2={xKey} key3={yKey} key4={rKey}/>
 </div>
-{/if}
-<slot name="legend"/>
-{#if legend && _zDomain}
-  <Legend domain={_zDomain} {colors} markerLength={Array.isArray(r) ? r[0] * 2 : r * 2} round={true}/>
 {/if}
 {#if footer}
   <Footer>{footer}</Footer>

--- a/src/charts/ScatterChart.svelte
+++ b/src/charts/ScatterChart.svelte
@@ -143,6 +143,10 @@
 {#if legend && _zDomain}
   <Legend domain={_zDomain} {colors} markerLength={12} round={true} {yAxisLabel}/>
 {/if}
+{#if yAxisLabel}
+<div style="margin-top: 40px"></div>
+{/if} 
+<!-- if there is no legend, then the yaxislabel gets cut off by the subtitle so this adds a bit of padding for the yaxislabel to show properly -->
 <slot name="options"/>
 <div class="chart-container" style="height: {typeof height == 'number' ? height + 'px' : height }" aria-hidden="true">
 	<LayerCake

--- a/src/charts/shared/AxisX.svelte
+++ b/src/charts/shared/AxisX.svelte
@@ -33,8 +33,7 @@
 	if (xTicksArray)
 		{await tick();
 		
-		{if ($width < mobileThreshold) {ticks = xTicksArray[0]} else {ticks = xTicksArray[1]}};
-		console.log('newticks',ticks);}
+		{if ($width < mobileThreshold) {ticks = xTicksArray[0]} else {ticks = xTicksArray[1]}};}
 
 	}; //async function that waits until the page has rendered before it calculates the newticks
 

--- a/src/charts/shared/AxisX.svelte
+++ b/src/charts/shared/AxisX.svelte
@@ -1,16 +1,17 @@
 <script>
-	import { getContext } from 'svelte';
+	import { getContext, tick } from 'svelte';
 	import { timeFormat } from 'd3-time-format'
 
-	const { height, xScale, xDomain, yRange } = getContext('LayerCake');
+	const { height, xScale, xDomain, yRange, width } = getContext('LayerCake');
 
 	const regex = /%(?:[YyBbMmdeHwWSzZNaAgGcpPZcrRUoOFDL]+)/;// this looks for strings that looks like time e.g. %b %Y
 
 	export let gridlines = true;
 	export let tickDashed = false;
 	export let tickMarks = false;
-	export let tickColor = '#b3b3b3';
-	export let textColor = '#707070';
+	export let tickColor = '#d9d9d9';
+	export let zeroColor = '#B3B3B3';
+	export let textColor = '#707071';
 	export let formatTick = d => d;
 	export let formatTickString = null;
 	export let snapTicks = false;
@@ -22,6 +23,27 @@
 	export let dyTick = tickMarks ? 8 : 0;
 	export let prefix = '';
 	export let suffix = '';
+	export let xAxisLabel = "x axis label";
+	export let xTicksArray;
+
+	let mobileThreshold = 400; //set the mobile threshold width
+
+	async function calculateTicks() {
+				
+	if (xTicksArray)
+		{await tick();
+		
+		{if ($width < mobileThreshold) {ticks = xTicksArray[0]} else {ticks = xTicksArray[1]}};
+		console.log('newticks',ticks);}
+
+	}; //async function that waits until the page has rendered before it calculates the newticks
+
+	$: if ($width) {calculateTicks()} //everytime width changes/screen resizes then it recalculates the number of ticks
+
+	// $: console.log('width check',$width < mobileThreshold)
+	// $: console.log('xTicksArray',xTicksArray)
+	// $: console.log('newticks',newticks)
+
 
 	if(formatTickString && formatTickString.match(regex)){formatTick = d => timeFormat(formatTickString)(d)} //if the regex test passes, make it a timeFormat function
 
@@ -64,10 +86,10 @@
 	{#each tickVals as tick, i}
 		<g class='tick tick-{tick}' transform='translate({$xScale(tick)},{Math.max(...$yRange)})'>
 			{#if gridlines !== false}
-				<line class="gridline" class:dashed={tickDashed} y1='{$height * -1}' y2='0' x1='0' x2='0' style:stroke='{tickColor}' style:stroke-width='{tick === 0 ? 1.5 : 1}' style:filter={tick !== 0 ? `contrast(calc(1/3)) brightness(1.5)` : null}></line>
+				<line class="gridline" class:dashed={tickDashed} y1='{$height * -1}' y2='0' x1='0' x2='0' style:stroke='{tick === 0 ? zeroColor : tickColor}'  style:stroke-width='{tick === 0 ? 1.5 : 1}' style:filter={tick !== 0 ? `contrast(calc(1/3)) brightness(1.5)` : null}></line>
 			{/if}
 			{#if tickMarks === true}
-				<line class="tick-mark" y1='{0}' y2='{dyTick}' x1='{xTick || isBandwidth ? $xScale.bandwidth() / 2 : 0}' x2='{xTick || isBandwidth ? $xScale.bandwidth() / 2 : 0}' style:stroke='{tickColor}' style:stroke-width='{tick === 0 ? 1.5 : 1}' style:filter={tick !== 0 ? `contrast(calc(1/3)) brightness(1.5)` : null}></line>
+				<line class="tick-mark" y1='{0}' y2='{dyTick}' x1='{xTick || isBandwidth ? $xScale.bandwidth() / 2 : 0}' x2='{xTick || isBandwidth ? $xScale.bandwidth() / 2 : 0}' style:stroke='{tick === 0 ? zeroColor : tickColor}'  style:stroke-width='{tick === 0 ? 1.5 : 1}' style:filter={tick !== 0 ? `contrast(calc(1/3)) brightness(1.5)` : null}></line>
 			{/if}
 			<text
 				x="{xTick || isBandwidth ? $xScale.bandwidth() / 2 : 0}"
@@ -80,6 +102,7 @@
 				</text>
 		</g>
 	{/each}
+	<text x={$width} y={$height +40} text-anchor="end" class="axisLabel">{xAxisLabel}</text>
 </g>
 
 <style>
@@ -92,9 +115,9 @@
 		stroke-dasharray: 0;
 	}
 
-	.tick line {
-		shape-rendering: crispEdges;
-	}
+	/* .tick line {
+		stroke: #d9d9d9;
+	} */
 
 	.dashed {
 		stroke-dasharray: 2;
@@ -105,5 +128,9 @@
 	}
 	.axis.snapTicks .tick.tick-0 text {
 		transform: translateX(-3px);
+	}
+	.axisLabel {
+		font-size: 14px;
+		fill: #707071;
 	}
 </style>

--- a/src/charts/shared/AxisY.svelte
+++ b/src/charts/shared/AxisY.svelte
@@ -2,7 +2,7 @@
 	import { getContext } from 'svelte';
 	import wrap from '../../js/wrap';
 
-	const { containerWidth, padding, xRange, yScale } = getContext('LayerCake');
+	const { containerWidth, padding, xRange, yScale, width, height } = getContext('LayerCake');
 
 	export let ticks = 4;
 	export let tickMarks = false;
@@ -15,13 +15,42 @@
 	export let wrapTicks = false;
 	export let xTick = 0;
 	export let yTick = 0;
-	export let dxTick = tickMarks ? 8 : 0;
-	export let dyTick = -4;
-	export let textAnchor = 'start';
+	export let dyTick = 4;
+	export let textAnchor = 'end';
 	export let prefix = '';
 	export let suffix = '';
+	export let yAxisLabel = '';
+	export let format = d => d;
+	export let widestTickLen;
+	export let charPixelWidth = 7.25;
+	export let tickLen;
+	export let tickMarkLength = undefined;
+	export let tickGutter = 10;
+	export let x1;
+
+	//assign the ticklength
+	$: tickLen =
+		tickMarks === true ?
+		(tickMarkLength ?? 6) : 0;
+
+	//var to calculate the width of the widest tick string
+	$: widestTickLen = Math.max(
+    10,
+    Math.max(...tickVals.map(d => format(d).toString().split('').reduce(calcStringLength, 0)))
+  );
+
+  //function to calculate the length of the widest tick string
+  function calcStringLength(sum, val) {
+    if (val === ',' || val === '.') return sum + charPixelWidth * 0.5;
+    return sum + charPixelWidth;
+  }
+
+//set x1 for the line and the tick text
+  	$: x1 = tickGutter - tickLen;
 
 	$: isBandwidth = typeof $yScale.bandwidth === 'function';
+
+	//calculate the width of the gridlines
 	$: gridlineWidth = (() => {
 		let width = $containerWidth;
 		if (isBandwidth) width -= $padding.left;
@@ -35,6 +64,7 @@
 			typeof ticks === 'function' ?
 				ticks($yScale.ticks()) :
 					$yScale.ticks(ticks);
+
 </script>
 
 <g class='axis y-axis' transform='translate({-$padding.left}, 0)'>
@@ -43,7 +73,7 @@
 			{#if gridlines !== false}
 				<line
 					class="gridline"
-					x1='0'
+					x1={x1 + widestTickLen}
 					x2='{gridlineWidth}'
 					y1={yTick + (isBandwidth ? ($yScale.bandwidth() / 2) : 0)}
 					y2={yTick + (isBandwidth ? ($yScale.bandwidth() / 2) : 0)}
@@ -56,7 +86,7 @@
 			{#if tickMarks === true}
 				<line
 					class='tick-mark'
-					x1='0'
+					x1={x1}
 					x2='{isBandwidth ? -6 : 6}'
 					y1={yTick + (isBandwidth ? ($yScale.bandwidth() / 2) : 0)}
 					y2={yTick + (isBandwidth ? ($yScale.bandwidth() / 2) : 0)}
@@ -66,7 +96,7 @@
 				></line>
 			{/if}
 			<text
-				x='{xTick + (isBandwidth ? -4 : dxTick)}'
+				x='{xTick + (isBandwidth ? -4 : (x1 + widestTickLen - 5))}'
 				y='{yTick + (isBandwidth ? $yScale.bandwidth() / 2 : 0) + (isBandwidth ? 4 : dyTick)}'
 				text-anchor='{isBandwidth ? 'end' : textAnchor}'
 				fill='{textColor}'
@@ -75,6 +105,8 @@
 				</text>
 		</g>
 	{/each}
+	<!-- add in the y axis label -->
+	<text x={2} y={-15} text-anchor="start" class="axisLabel">{yAxisLabel}</text>
 </g>
 
 <style>
@@ -88,5 +120,9 @@
 
 	.tick.tick-0 line {
 		stroke-dasharray: 0;
+	}
+	.axisLabel {
+		font-size: 14px;
+		fill: #707071;
 	}
 </style>

--- a/src/charts/shared/Bar.svelte
+++ b/src/charts/shared/Bar.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { getContext, createEventDispatcher } from 'svelte';
+	import { format } from 'd3-format'
 	
 	const { data, xScale, zGet, xDomain, zRange, config, custom } = getContext('LayerCake');
 	const dispatch = createEventDispatcher()
@@ -10,6 +11,8 @@
 	export let selected = null;
 	export let highlighted = [];
 	export let overlayFill = false;
+	export let directLabel;
+	export let xFormatTickString;
 
 	let coords = $custom.coords;
 	let idKey = $custom.idKey;
@@ -79,20 +82,23 @@
 		  <!-- svelte-ignore a11y-click-events-have-key-events -->
 		  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 		  <polygon
-			  class='bar-rect'
-			  data-id="{j}"
-				transform="translate({mode == 'barcode' || (mode == 'comparison' && i > 0) ? -markerWidth / 2 : 0} 0)"
-			  points="{makePoints($xScale(d.x0), $xScale(d.x1), d.y0, d.y1)}"
-				stroke="{$data[i][j][idKey] == hovered ? colorHover : $data[i][j][idKey] == selected ? colorSelect : colorHighlight}"
-				stroke-width="{$data[i][j][idKey] == hovered || $data[i][j][idKey] == selected || highlighted.includes($data[i][j][idKey]) ? lineWidth : 0}"
-			  fill="{overlayFill && $data[i][j][idKey] == selected ? colorSelect : overlayFill && highlighted.includes($data[i][j][idKey]) ? colorHighlight : $config.z ? $zGet($data[i][j]) : $zRange[0]}"
-				on:mouseover={hover ? (e) => doHover(e, $data[i][j]) : null}
-				on:mouseleave={hover ? (e) => doHover(e, null) : null}
-				on:focus={select ? (e) => doHover(e, $data[i][j]) : null}
-				on:blur={select ? (e) => doHover(e, null) : null}
-				on:click={select ? (e)  => doSelect(e, $data[i][j]) : null}
-				tabindex="{hover || select ? 0 : -1}"
+			class='bar-rect'
+			data-id="{j}"
+			transform="translate({mode == 'barcode' || (mode == 'comparison' && i > 0) ? -markerWidth / 2 : 0} 0)"
+			points="{makePoints($xScale(d.x0), $xScale(d.x1), d.y0, d.y1)}"
+			stroke="{$data[i][j][idKey] == hovered ? colorHover : $data[i][j][idKey] == selected ? colorSelect : colorHighlight}"
+			stroke-width="{$data[i][j][idKey] == hovered || $data[i][j][idKey] == selected || highlighted.includes($data[i][j][idKey]) ? lineWidth : 0}"
+			fill="{overlayFill && $data[i][j][idKey] == selected ? colorSelect : overlayFill && highlighted.includes($data[i][j][idKey]) ? colorHighlight : $config.z ? $zGet($data[i][j]) : $zRange[0]}"
+			on:mouseover={hover ? (e) => doHover(e, $data[i][j]) : null}
+			on:mouseleave={hover ? (e) => doHover(e, null) : null}
+			on:focus={select ? (e) => doHover(e, $data[i][j]) : null}
+			on:blur={select ? (e) => doHover(e, null) : null}
+			on:click={select ? (e)  => doSelect(e, $data[i][j]) : null}
+			tabindex="{hover || select ? 0 : -1}"
 		  />
+		  {#if directLabel === "true"}
+		  <text x={$xScale(d.x1)-5} y={d.y1-10} fill="#fff" class="bar-label">{format(xFormatTickString)(d.x1)}</text>
+		  {/if}
 			{/if}
 	  {/each}
 	{/each}
@@ -102,5 +108,12 @@
 <style>
 	.bar-group polygon, .line-group polygon {
 		shape-rendering: crispEdges;
+	}
+
+	.bar-label {
+		text-anchor: end;
+		font-weight: 600;
+		font-size: 14px;
+		fill:"#fff";
 	}
 </style>

--- a/src/charts/shared/Footer.svelte
+++ b/src/charts/shared/Footer.svelte
@@ -4,6 +4,6 @@
 	.chart-footer {
 		font-size: .8em;
 		color: grey;
-		margin-top: 5px;
+		margin-top: 30px;
 	}
 </style>

--- a/src/charts/shared/Footer.svelte
+++ b/src/charts/shared/Footer.svelte
@@ -2,8 +2,9 @@
 
 <style>
 	.chart-footer {
-		font-size: .8em;
-		color: grey;
+		font-size: 16px;
+		font-weight: 400;
+		color: #707071 ;
 		margin-top: 30px;
 	}
 </style>

--- a/src/charts/shared/Labels.svelte
+++ b/src/charts/shared/Labels.svelte
@@ -20,6 +20,7 @@
 	let colorHover = $custom.colorHover ? $custom.colorHover : 'orange';
 	let colorSelect = $custom.colorSelect ? $custom.colorSelect : '#206095';
 	let radius = 8; // For spreading labels
+	let rCircle = 4;
 
 	const regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/; //regex test for something that looks like a date 2017-01-01T00:00:00.000Z
 
@@ -48,7 +49,7 @@
 	};
 
 
-
+	// $: console.log($padding)
 	$: coordsWithLabels = $coords?.[0]?.[0]?.y && spreadLabels ? addLabelCoords($coords, radius) : $coords;
 </script>
 
@@ -89,7 +90,7 @@
 						<circle
 							cx={$xScale(d[d.length - 1].x)}
 							cy={$yScale(d[d.length - 1].y)}
-							r="5"
+							r={rCircle}
 							fill={labelAll && $config.z
 								? $zGet($data[i][0])
 								: $data[i][0][idKey] === hovered
@@ -113,7 +114,7 @@
 						y={spreadLabels && d[d.length - 1].ly
 							? d[d.length - 1].ly
 							: $yScale(d[d.length - 1].y)}
-						use:wrap={{ disable: !textWrap, width: $padding.right }}
+						use:wrap={{ disable: !textWrap, width: (+$padding.left) }}
 						use:raiseMe={{
 							disable: $data[i][0][idKey] !== hovered,
 						}}

--- a/src/charts/shared/Legend.svelte
+++ b/src/charts/shared/Legend.svelte
@@ -1,53 +1,102 @@
 <script>
   export let domain = null;
   export let colors = null;
-  export let line = false; // true if line chart
   export let comparison = false; // true if chart uses bars + markers for comparison
   export let confidence = false; // true if chart uses confidence intervals
   export let horizontal = true; // true if marker lines should be horizontal, false if vertical
   export let markerWidth = 2.5;
-  export let markerLength = 13;
+  export let markerLength = 12;
   export let round = false; // to represent round markers
+  export let yAxisLabel;
 
   $: _domain = confidence ? ["Estimate", "Confidence interval"] : domain;
 </script>
 
-{#if Array.isArray(_domain) && Array.isArray(colors)}
-  <ul class="legend" aria-hidden="true">
+<!-- {#if Array.isArray(_domain) && Array.isArray(colors)}
+  <ul class="legend" aria-hidden="true" style:margin-bottom={yAxisLabel === "" ? "15px":"35px"}>
     {#each _domain as label, i}
       <li>
         <div
           class="bullet"
           class:round
           style:background-color="{confidence ? colors[0] : colors[i]}"
-          style:width="{!horizontal && (line || (comparison && i != 0) || (confidence && i == 0)) ? markerWidth : markerLength}px"
-          style:height="{horizontal && (line || (comparison && i != 0) || (confidence && i == 0)) ? markerWidth : markerLength}px"
+          style:width="{!horizontal && ((comparison && i != 0) || (confidence && i == 0)) ? markerWidth : markerLength}px"
+          style:height="{horizontal && ((comparison && i != 0) || (confidence && i == 0)) ? markerWidth : markerLength}px"
           style:opacity="{confidence && i == 1 ? '0.3' : null}"
         />
         {label}
       </li>
     {/each}
   </ul>
+{/if} -->
+
+<!-- replaced the bullet approach with flex div approach so the legend items run better across multiple lines -->
+
+{#if Array.isArray(_domain) && Array.isArray(colors)}
+  <div id="legend" aria-hidden="true" style:margin-bottom={yAxisLabel === "" ? "15px":"35px"}>
+    {#each _domain as label, i}
+    <div class='legend--item'>
+      <div
+        class="legend--icon--circle"
+        style:background-color="{confidence ? colors[0] : colors[i]}"
+        style:width="{!horizontal && ((comparison && i != 0) || (confidence && i == 0)) ? markerWidth : markerLength}px"
+        style:height="{horizontal && ((comparison && i != 0) || (confidence && i == 0)) ? markerWidth : markerLength}px"
+        style:opacity="{confidence && i == 1 ? '0.3' : null}"
+      />
+      <div ><p class='legend--text'> {label}</p></div>
+    </div>
+    {/each}
+  </div>
 {/if}
 
 <style>
-  ul.legend {
-    margin: 0;
+  /* ul.legend {
     padding: 0;
+    list-style-position: inside;
   }
   ul.legend li {
     display: inline;
     font-size: .8em;
   }
-  ul.legend li + li {
-    margin-left: 8px;
-  }
   .bullet {
 		display: inline-block;
     vertical-align: middle;
     transform: translateY(-1px);
+    border-radius: 50%;
+    margin-left: 8px;
+
 	}
   .round {
     border-radius: 50%;
+  } */
+
+  #legend {
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: 10px;
+  margin-left: 1px;
   }
+
+  .legend--item {
+  display: flex;
+  padding-right: 20px;
+  padding-bottom: 12px;
+}
+
+.legend--icon--circle {
+  height: 12px;
+  width: 12px;
+  border-radius: 50%;
+  align-self: center;
+  flex-shrink: 0;
+  forced-color-adjust: none;
+}
+
+.legend--text {
+  color: #414042;
+  line-height: 14px;
+  font-size: 14px;
+  padding-left: 6px;
+  margin: 0;
+}
 </style>

--- a/src/charts/shared/Subtitle.svelte
+++ b/src/charts/shared/Subtitle.svelte
@@ -5,6 +5,9 @@
 <style>
 	.chart-subtitle {
     margin-top: -6px;
-		margin-bottom: 10px;
+	margin-bottom: 10px;
+	color: #222222;
+	font-weight: 600;
+	font-size: 18px;
 	}
 </style>

--- a/src/charts/shared/Title.svelte
+++ b/src/charts/shared/Title.svelte
@@ -4,8 +4,10 @@
 
 <style>
 	.chart-title {
-		font-size: 1.1em;
-		font-weight: bold;
-		margin-bottom: 10px;
+	font-size: 1.1em;
+	margin-bottom: 10px;
+	color: #222222;
+	font-weight: 700;
+	font-size: 22px;
 	}
 </style>


### PR DESCRIPTION
I have made some updates to the chart styles, so they're more in keeping with the current style guide. I have logged my changes [here](https://officenationalstatistics-my.sharepoint.com/:x:/g/personal/erin_vickery_ons_gov_uk/EdtdwNQqT-1Bov94yrh61QEBqNAY0h_yIo31gQ9XIvupBA?e=LasBbl). Changes include:

- Moved legend above the chart
- Updated legend symbols to match chart style guide
- Updated gridlines to match chart style guide
- Added X and Y axis label props to edit via the pug
- Updated text to match chart style guide
- Fixed the wrap
- Adjusted Y axis labels to sit next to line, not above